### PR TITLE
changed isDesktopOnly to false

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
 	"description": "Autocomplete HTML tags.",
 	"author": "Brian Carlsen",
 	"authorUrl": "https://github.com/bicarlsen",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }


### PR DESCRIPTION
No changes need to be made to this plugin for it to work on mobile, so the setting that prevents its installation on mobile can be disabled. This was tested using my fork.
